### PR TITLE
Added support for 2-way mentions including @ role, @ here & @ everyone.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.3.0
 - Mentions in Discord shows proper names in Minecraft
+- Mentions sent from Minecraft are supported if the player has permission to do so
 - Attachments in Discord shows proper links in Minecraft
 - Role-based configurations
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,23 @@ Configuration is stored in `config.json` file.
 
 You can find some example configurations in `examples` folders.
 
-### Supported Placeholders
+### Chat Placeholders
 - %s - the message sent via discord
 - %a - the nickname of the message author or username if nickname is unavailable
 - %u - the username of the author. This is used if you want to disallow Discord nickname.
 - %r - the name of the highest Discord role held by the message author. Color of the role will also be translated into Minecraft color automatically.
 - %g - the current game of the message author
-- %s - the message sent from discord
+
+### Additional Permissions
+ **Only applicable to unathenticated users**
+
+| Permission | Use |
+|---------|-----------|
+| `discordbridge.mention.name` <br> `discordbridge.mention.name.<name>` | Allows `@username`/`@nickname` mentions to be sent from Minecraft |
+| `discordbridge.mention.role` <br> `discordbridge.mention.role.<role>`  | Allows `@role` mentions - the role must have "Allow anyone to @mention" set |
+| `discordbridge.mention.here` | Allows the `@here` mention<sup>1</sup> |
+| `discordbridge.mention.everyone` | Allows the `@everyone` mention<sup>1</sup> |
+>  <sup>1</sup> The bot must have permission to "Mention Everyone" in order to use `@here` & `@everyone`.
 
 ## Notes
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 defaultTasks 'build', 'shadowJar'
 
 group = 'com.nguyenquyhy'
-version = '2.2.0'
+version = '2.3.0'
 description = 'A plugin to connect Discord and Minecraft'
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/nguyenquyhy/discordbridge/DiscordBridge.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/DiscordBridge.java
@@ -33,7 +33,7 @@ import java.util.*;
 /**
  * Created by Hy on 1/4/2016.
  */
-@Plugin(id = "discordbridge", name = "Discord Bridge", version = "2.2.0",
+@Plugin(id = "discordbridge", name = "Discord Bridge", version = "2.3.0",
         description = "A Sponge plugin to connect your Minecraft server with Discord", authors = { "Hy" })
 public class DiscordBridge {
 

--- a/src/main/java/com/nguyenquyhy/discordbridge/listeners/ChatListener.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/listeners/ChatListener.java
@@ -1,7 +1,6 @@
 package com.nguyenquyhy.discordbridge.listeners;
 
 import com.nguyenquyhy.discordbridge.DiscordBridge;
-import com.nguyenquyhy.discordbridge.logics.MessageHandler;
 import com.nguyenquyhy.discordbridge.models.ChannelConfig;
 import com.nguyenquyhy.discordbridge.models.GlobalConfig;
 import com.nguyenquyhy.discordbridge.utils.ChannelUtil;
@@ -10,7 +9,6 @@ import com.nguyenquyhy.discordbridge.utils.TextUtil;
 import de.btobastian.javacord.DiscordAPI;
 import de.btobastian.javacord.entities.Channel;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
@@ -77,6 +75,9 @@ public class ChatListener {
                                 ErrorMessages.CHANNEL_NOT_FOUND.log(channelConfig.discordId);
                                 return;
                             }
+
+                            // Format Mentions for Discord
+                            plainString = TextUtil.formatMinecraftMention(channel.getServer(), plainString, player.get(), isBotAccount);
 
                             if (isBotAccount) {
 //                                if (channel == null) {


### PR DESCRIPTION
Minecraft mentions require permission to be used by unauthenticated users. Players without the proper permissions will have their mentions sent as plain text.