### PR TITLE
Prevent blank death messages

### DIFF
--- a/src/main/java/com/nguyenquyhy/discordbridge/listeners/DeathListener.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/listeners/DeathListener.java
@@ -19,7 +19,7 @@ public class DeathListener {
         GlobalConfig config = mod.getConfig();
         DiscordAPI client = mod.getBotClient();
 
-        if (!(event.getTargetEntity() instanceof Player) || event.isMessageCancelled()) return;
+        if (!(event.getTargetEntity() instanceof Player) || event.isMessageCancelled() || StringUtils.isBlank(event.getMessage().toPlain())) return;
         Player player = (Player) event.getTargetEntity();
 
         if (client != null) {


### PR DESCRIPTION
Blank death messages are no longer sent if a plugin removes the death message but fails to cancel it.